### PR TITLE
Change: Freeze registration data

### DIFF
--- a/app/views/decidim/devise/registrations/new_step_2.html.erb
+++ b/app/views/decidim/devise/registrations/new_step_2.html.erb
@@ -23,6 +23,7 @@
 
   <div class="row">
     <div class="columns large-6 medium-10 medium-centered">
+      <%= cell("decidim/announcement", {announcement: t(".update_user_data_help"), callout_class: "warning"}) %>
 
       <%= decidim_form_for(@form, as: resource_name, url: registration_path(resource_name), html: { class: "register-form new_user", id: "register-form" }) do |f| %>
         <%= invisible_captcha %>
@@ -30,23 +31,23 @@
           <div class="card__content">
             <div class="user-person">
               <div class="field">
-                <%= f.text_field :name, help_text: t(".username_help") %>
+                <%= f.text_field :name, help_text: t(".username_help"), readonly: true %>
               </div>
             </div>
 
             <div class="user-person">
               <div class="field">
-                <%= f.text_field :nickname, help_text: t(".nickname_help", organization: current_organization.name) %>
+                <%= f.text_field :nickname, help_text: t(".nickname_help", organization: current_organization.name), readonly: true %>
               </div>
             </div>
 
             <div class="field">
-              <%= f.email_field :email %>
+              <%= f.email_field :email, readonly: true %>
             </div>
 
             <!-- New fields -->
             <div class="field">
-              <%= f.text_field :phone_number, help_text: t(".phone_number_help") %>
+              <%= f.text_field :phone_number, help_text: t(".phone_number_help"), readonly: true %>
             </div>
             <%= f.hidden_field :document_number %>
             <%= f.hidden_field :member_of_code %>

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -55,6 +55,10 @@ ca:
           terms: els termes i condicions d'ús
           tos_agreement: En registrar-te acceptes %{link}.
           tos_title: Termes del servei
+          update_user_data_help: Si les teves dades personals són incorrectes, posa't
+            en contacte amb <strong>administracio@erc.cat</strong>.<br />La plataforma
+            no permet modificar les dades personals, siusplau, no creïs un compte
+            amb dades incorrectes.
           username_help: Nom públic que apareixerà en les teves publicacions. Amb
             l'objectiu de garantir l'anonimat pot ser qualsevol nom.
   devise:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -45,6 +45,8 @@ en:
           terms: the terms and conditions of use
           tos_agreement: By signing up you agree to %{link}.
           tos_title: Terms of Service
+          update_user_data_help: Please, contact administracio@erc.cat if your data
+            is not up to date.
           username_help: Public name that appears on your posts. With the aim of guaranteeing
             the anonymity, can be any name.
   devise:

--- a/spec/system/decidim/erc/crm_authenticable/registration_spec.rb
+++ b/spec/system/decidim/erc/crm_authenticable/registration_spec.rb
@@ -39,10 +39,12 @@ describe "Registration", type: :system do
 
       it "prefilles the 'Registration form' with data from CiviCRM" do
         within "#register-form" do
-          expect(page).to have_field("user_name", with: "John Doe")
-          expect(page).to have_field("user_nickname", with: "john_doe")
-          expect(page).to have_field("user_email", with: "john.doe@example.org")
-          expect(page).to have_field("user_phone_number", with: "666-666-666")
+          # Data returned from CiviCRM should be readonly and users must be informed.
+          expect(page).to have_tag("div.callout.warning", text: /administracio@erc.cat/)
+          expect(page).to have_field("user_name", with: "John Doe", readonly: true)
+          expect(page).to have_field("user_nickname", with: "john_doe", readonly: true)
+          expect(page).to have_field("user_email", with: "john.doe@example.org", readonly: true)
+          expect(page).to have_field("user_phone_number", with: "666-666-666", readonly: true)
           expect(page).to have_field("user_password", with: "")
           expect(page).to have_field("user_password_confirmation", with: "")
         end


### PR DESCRIPTION
#### :tophat: What? Why?
> Quedem que en cap moment es podran modificar les dades dins de la plataforma Decidim [...]
caldrà remetre a la militància a administració per a què actualitzin les dades.

#### :clipboard: Subtasks
- [x] Add tests

### :camera: Screenshots (optional)
![registration_form](https://user-images.githubusercontent.com/40306853/66563422-0a134900-eb5e-11e9-976d-336b079b5813.png)
