### PR TITLE
Fix: disambiguate nicknames (2)

### DIFF
--- a/app/forms/decidim/erc/crm_authenticable/identity_document_form.rb
+++ b/app/forms/decidim/erc/crm_authenticable/identity_document_form.rb
@@ -73,7 +73,7 @@ module Decidim
         # Returns a unique nickname scoped to the organization.
         def nickname
           initials = user_data["display_name"].split.map { |w| w.chars.first }.join
-          UserBaseEntity.nicknamize(initials, organization: current_organization).upcase
+          User.nicknamize(initials, organization: current_organization)
         end
 
         def encoded_document_number


### PR DESCRIPTION
> Quan he fet el bugfix no he tingut en compte que el nickname s'estava passant a majúscules **després** de fer la comprovació a la base de dades, i això ha ocasionat un altre error diferent.
> 
> Per exemple, per l'usuari amb nom "Anna Costa i Vidal" es feia la comprovació del nickname amb "ACiV" (no existeix) però s'intentava crear l'usuari amb el nickname "ACIV" (ja existeix). 