### PR TITLE
Update Scopes instead of creating new ones if code is the same

### DIFF
--- a/lib/file_manager.rb
+++ b/lib/file_manager.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module FileManager
+  def write_config_yaml!(filename, content)
+    File.write(filepath(filename), content.to_yaml)
+    puts "File generated 'config/civi_crm/#{filename}.yml'"
+  end
+
+  def filepath(filename)
+    Dir.mkdir("config/civi_crm") unless File.directory?("config/civi_crm")
+    Rails.root.join("config", "civi_crm", "#{filename}.yml").to_s
+  end
+
+  def load_config_yaml(filename)
+    YAML.load_file(filepath(filename))
+  end
+end

--- a/lib/tasks/civi_crm.rake
+++ b/lib/tasks/civi_crm.rake
@@ -114,11 +114,12 @@ namespace :civi_crm do
         next if display_name[/\d/]
 
         scope_name = display_name.strip
-        Decidim::Scope.find_or_create_by!(
+        scope= Decidim::Scope.find_or_initialize_by(
           organization: organization,
-          name: { "ca" => scope_name, "en" => scope_name, "es" => scope_name },
           code: contact_id
         )
+        scope.name= { "ca" => scope_name, "en" => scope_name, "es" => scope_name }
+        scope.save!
       end
     end
   end

--- a/lib/tasks/civi_crm.rake
+++ b/lib/tasks/civi_crm.rake
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
-require 'csv'
+
+require "csv"
 
 namespace :civi_crm do
   task init: ["import:all", "generate:all", "create:scopes"]
@@ -69,45 +70,45 @@ namespace :civi_crm do
 
     desc "Generates a YAML file with the CSV with 'Comarcal' tag"
     task comarcals: :environment do
-      csv_text = File.read('tmp/scopes_codes.csv')
+      csv_text = File.read("tmp/scopes_codes.csv")
       csv = CSV.parse(csv_text, headers: true)
-      
-      csv = csv.select { |row| row['type'] == 'FC' }
-      csv = csv.map { |row| row.to_h }
+
+      csv = csv.select { |row| row["type"] == "FC" }
+      csv = csv.map(&:to_h)
 
       result = get_code_and_display_name(csv)
-      write_config_yaml!('comarcals', result)
+      write_config_yaml!("comarcals", result)
     end
 
     desc "Generates a YAML file with the CSV with 'Regional' tag"
     task regionals: :environment do
-      csv_text = File.read('tmp/scopes_codes.csv')
+      csv_text = File.read("tmp/scopes_codes.csv")
       csv = CSV.parse(csv_text, headers: true)
-      
-      csv = csv.select { |row| row['type'] == 'FR' }
-      csv = csv.map { |row| row.to_h }
+
+      csv = csv.select { |row| row["type"] == "FR" }
+      csv = csv.map(&:to_h)
 
       result = get_code_and_display_name(csv)
-      write_config_yaml!('regionals', result)
+      write_config_yaml!("regionals", result)
     end
 
     desc "Generates a YAML file with the CSV with 'Locals' tag"
     task locals: :environment do
-      csv_text = File.read('tmp/scopes_codes.csv')
+      csv_text = File.read("tmp/scopes_codes.csv")
       csv = CSV.parse(csv_text, headers: true)
-      
-      csv = csv.select { |row| row['type'] == 'SL' }
-      csv = csv.map { |row| row.to_h }
+
+      csv = csv.select { |row| row["type"] == "SL" }
+      csv = csv.map(&:to_h)
 
       result = get_code_and_display_name(csv)
-      write_config_yaml!('locals', result)
+      write_config_yaml!("locals", result)
     end
 
     desc "Generates a YAML file with the relationship between CSV 'Local' and 'Comarcal'"
     task local_comarcal_relationships: :environment do
       local_ids = load_config_yaml("locals").keys
       comarcal_ids = load_config_yaml("comarcals").keys
-      result = get_code_relationships(local_ids, comarcal_ids, 'comarcal')
+      result = get_code_relationships(local_ids, comarcal_ids, "comarcal")
       write_config_yaml!("local_comarcal_relationships", result)
     end
 
@@ -115,24 +116,24 @@ namespace :civi_crm do
     task local_regional_relationships: :environment do
       local_ids = load_config_yaml("locals").keys
       regional_ids = load_config_yaml("regionals").keys
-      result = get_code_relationships(local_ids, regional_ids, 'regional')
+      result = get_code_relationships(local_ids, regional_ids, "regional")
       write_config_yaml!("local_regional_relationships", result)
     end
 
     def get_code_and_display_name(body)
-      body.map! { |element| { element['code'] => element['name'] } }.reduce(Hash.new, :merge)
+      body.map! { |element| { element["code"] => element["name"] } }.reduce({}, :merge)
     end
 
-    def get_code_relationships(local_ids, filter_ids, scope_type)
+    def get_code_relationships(local_ids, _filter_ids, scope_type)
       local_ids.each_with_object({}) do |element, memo|
-        csv_text = File.read('tmp/scopes_hierarchy.csv')
+        csv_text = File.read("tmp/scopes_hierarchy.csv")
         csv = CSV.parse(csv_text, headers: true)
 
         csv = csv.select { |row| row["SL"] == element }.first.to_h
-        next unless csv.present?
+        next if csv.blank?
 
-        memo[csv['SL']] = csv["FC"] if scope_type == 'comarcal'
-        memo[csv['SL']] = csv["FR"] if scope_type == 'regional'
+        memo[csv["SL"]] = csv["FC"] if scope_type == "comarcal"
+        memo[csv["SL"]] = csv["FR"] if scope_type == "regional"
       end
     end
   end

--- a/lib/tasks/civi_crm.rake
+++ b/lib/tasks/civi_crm.rake
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'csv'
 
 namespace :civi_crm do
   task init: ["import:all", "generate:all", "create:scopes"]
@@ -59,6 +60,79 @@ namespace :civi_crm do
         next unless (relationship = relationships.find { |r| r["contact_id_b"].in?(filter_ids) })
 
         memo[element["contact_id"]] = relationship["contact_id_b"]
+      end
+    end
+  end
+
+  namespace :import_by_csv do
+    task all: [:comarcals, :regionals, :locals, :local_comarcal_relationships, :local_regional_relationships]
+
+    desc "Generates a YAML file with the CSV with 'Comarcal' tag"
+    task comarcals: :environment do
+      csv_text = File.read('tmp/scopes_codes.csv')
+      csv = CSV.parse(csv_text, headers: true)
+      
+      csv = csv.select { |row| row['type'] == 'FC' }
+      csv = csv.map { |row| row.to_h }
+
+      result = get_code_and_display_name(csv)
+      write_config_yaml!('comarcals', result)
+    end
+
+    desc "Generates a YAML file with the CSV with 'Regional' tag"
+    task regionals: :environment do
+      csv_text = File.read('tmp/scopes_codes.csv')
+      csv = CSV.parse(csv_text, headers: true)
+      
+      csv = csv.select { |row| row['type'] == 'FR' }
+      csv = csv.map { |row| row.to_h }
+
+      result = get_code_and_display_name(csv)
+      write_config_yaml!('regionals', result)
+    end
+
+    desc "Generates a YAML file with the CSV with 'Locals' tag"
+    task locals: :environment do
+      csv_text = File.read('tmp/scopes_codes.csv')
+      csv = CSV.parse(csv_text, headers: true)
+      
+      csv = csv.select { |row| row['type'] == 'SL' }
+      csv = csv.map { |row| row.to_h }
+
+      result = get_code_and_display_name(csv)
+      write_config_yaml!('locals', result)
+    end
+
+    desc "Generates a YAML file with the relationship between CSV 'Local' and 'Comarcal'"
+    task local_comarcal_relationships: :environment do
+      local_ids = load_config_yaml("locals").keys
+      comarcal_ids = load_config_yaml("comarcals").keys
+      result = get_code_relationships(local_ids, comarcal_ids, 'comarcal')
+      write_config_yaml!("local_comarcal_relationships", result)
+    end
+
+    desc "Generates a YAML file with the relationship between CSV 'Local' and 'Regional'"
+    task local_regional_relationships: :environment do
+      local_ids = load_config_yaml("locals").keys
+      regional_ids = load_config_yaml("regionals").keys
+      result = get_code_relationships(local_ids, regional_ids, 'regional')
+      write_config_yaml!("local_regional_relationships", result)
+    end
+
+    def get_code_and_display_name(body)
+      body.map! { |element| { element['code'] => element['name'] } }.reduce(Hash.new, :merge)
+    end
+
+    def get_code_relationships(local_ids, filter_ids, scope_type)
+      local_ids.each_with_object({}) do |element, memo|
+        csv_text = File.read('tmp/scopes_hierarchy.csv')
+        csv = CSV.parse(csv_text, headers: true)
+
+        csv = csv.select { |row| row["SL"] == element }.first.to_h
+        next unless csv.present?
+
+        memo[csv['SL']] = csv["FC"] if scope_type == 'comarcal'
+        memo[csv['SL']] = csv["FR"] if scope_type == 'regional'
       end
     end
   end

--- a/lib/tasks/civi_crm.rake
+++ b/lib/tasks/civi_crm.rake
@@ -114,11 +114,11 @@ namespace :civi_crm do
         next if display_name[/\d/]
 
         scope_name = display_name.strip
-        scope= Decidim::Scope.find_or_initialize_by(
+        scope = Decidim::Scope.find_or_initialize_by(
           organization: organization,
           code: contact_id
         )
-        scope.name= { "ca" => scope_name, "en" => scope_name, "es" => scope_name }
+        scope.name = { "ca" => scope_name, "en" => scope_name, "es" => scope_name }
         scope.save!
       end
     end

--- a/lib/tasks/erc_auth.rake
+++ b/lib/tasks/erc_auth.rake
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require "csv"
+require "file_manager"
+
+namespace :erc_auth do
+  include FileManager
+
+  namespace :csv_import do
+    task all: [:comarcals, :regionals, :locals, :local_comarcal_relationships, :local_regional_relationships]
+
+    desc "Generates a YAML file with the CSV with 'Comarcal' tag"
+    task comarcals: :environment do
+      csv_text = File.read("tmp/scopes_codes.csv")
+      csv = CSV.parse(csv_text, headers: true)
+
+      csv = csv.select { |row| row["type"] == "FC" }
+      csv = csv.map(&:to_h)
+
+      result = get_code_and_display_name(csv)
+      write_config_yaml!("comarcals", result)
+    end
+
+    desc "Generates a YAML file with the CSV with 'Regional' tag"
+    task regionals: :environment do
+      csv_text = File.read("tmp/scopes_codes.csv")
+      csv = CSV.parse(csv_text, headers: true)
+
+      csv = csv.select { |row| row["type"] == "FR" }
+      csv = csv.map(&:to_h)
+
+      result = get_code_and_display_name(csv)
+      write_config_yaml!("regionals", result)
+    end
+
+    desc "Generates a YAML file with the CSV with 'Locals' tag"
+    task locals: :environment do
+      csv_text = File.read("tmp/scopes_codes.csv")
+      csv = CSV.parse(csv_text, headers: true)
+
+      csv = csv.select { |row| row["type"] == "SL" }
+      csv = csv.map(&:to_h)
+
+      result = get_code_and_display_name(csv)
+      write_config_yaml!("locals", result)
+    end
+
+    desc "Generates a YAML file with the relationship between CSV 'Local' and 'Comarcal'"
+    task local_comarcal_relationships: :environment do
+      local_ids = load_config_yaml("locals").keys
+      comarcal_ids = load_config_yaml("comarcals").keys
+      result = get_code_relationships(local_ids, comarcal_ids, "comarcal")
+      write_config_yaml!("local_comarcal_relationships", result)
+    end
+
+    desc "Generates a YAML file with the relationship between CSV 'Local' and 'Regional'"
+    task local_regional_relationships: :environment do
+      local_ids = load_config_yaml("locals").keys
+      regional_ids = load_config_yaml("regionals").keys
+      result = get_code_relationships(local_ids, regional_ids, "regional")
+      write_config_yaml!("local_regional_relationships", result)
+    end
+
+    def get_code_and_display_name(body)
+      body.map! { |element| { element["code"] => element["name"] } }.reduce({}, :merge)
+    end
+
+    def get_code_relationships(local_ids, _filter_ids, scope_type)
+      local_ids.each_with_object({}) do |element, memo|
+        csv_text = File.read("tmp/scopes_hierarchy.csv")
+        csv = CSV.parse(csv_text, headers: true)
+
+        csv = csv.select { |row| row["SL"] == element }.first.to_h
+        next if csv.blank?
+
+        case scope_type
+        when "comarcal"
+          memo[csv["SL"]] = csv["FC"]
+        when "regional"
+          memo[csv["SL"]] = csv["FR"]
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
When updating scopes from yaml files if the code was the same but the name changed a new scope was created.
This PR resolves this situation and simply updates the Scope instead of resulting in two scopes with the same code and different names.