### PR TITLE
Update verstion to 1.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+### Version 1.1.6
+- Update rake tasks with csv scopes (#28)
 ### Version 1.1.5
 - Change how the signup against CSV is enabled (#26)
 - Upgrade to Ruby 2.7.2 (#26)

--- a/lib/decidim/erc/crm_authenticable/version.rb
+++ b/lib/decidim/erc/crm_authenticable/version.rb
@@ -4,7 +4,7 @@ module Decidim
   module Erc
     module CrmAuthenticable
       def self.version
-        "1.1.5"
+        "1.1.6"
       end
 
       def self.decidim_version


### PR DESCRIPTION
#### :tophat: What? Why?
Update version to 1.1.6 with rake tasks changes.
